### PR TITLE
Se agrega un boton para terminar con el pomodoro/descanso antes sin reiniciar la cuenta

### DIFF
--- a/src/components/Timer/timer.js
+++ b/src/components/Timer/timer.js
@@ -50,9 +50,11 @@ export default function Timer(props) {
       if (((cycles + 1) % 4) === 0) {
         setTime(props.timer.longBreak * 60);
         setMode("Long Break")
+        pauseTimer();
       } else {
         setTime(props.timer.break * 60);
         setMode("Break");
+        pauseTimer();
       }
       setCycles((cycles) => cycles + 1);
 
@@ -114,6 +116,9 @@ export default function Timer(props) {
         }
         <button onClick={restartTimer} type="button" className="btn btn-light">
           <span className="material-symbols-outlined">replay</span>
+        </button>
+        <button onClick={switchMode} type="button" className="btn btn-light">
+          <span className="material-symbols-outlined">stop</span>
         </button>
       </div>
 

--- a/src/components/Timer/timer.js
+++ b/src/components/Timer/timer.js
@@ -50,11 +50,9 @@ export default function Timer(props) {
       if (((cycles + 1) % 4) === 0) {
         setTime(props.timer.longBreak * 60);
         setMode("Long Break")
-        pauseTimer();
       } else {
         setTime(props.timer.break * 60);
         setMode("Break");
-        pauseTimer();
       }
       setCycles((cycles) => cycles + 1);
 


### PR DESCRIPTION
## Summary of changes

Se agregó un botón nuevo que permite al usuario finalizar un pomodoro o descanso prematuramente, sin la necesidad de resetear todo el timer o resetear la cuenta de pomodoros completados

Closes #77 

